### PR TITLE
Use tags for update

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ max_active_tasks=1
 erase_time_on_delete=false 
 # those are tags in taskwarrior.When you add one of them the time tracking will be deleted from timewarrior
 clear_time_tags=cleartime,ctime,deletetime,dtime
-update_time_tags=updatetime,utime,recalc
+update_time_tags=update,updatetime,utime,recalc
 create_time_when_add_task=false
 rate_per_hour=10
 rate_per_hour_decimals=2
@@ -110,6 +110,8 @@ or
 
 Update time tracking 
 
+`task 1 mod +update`
+or
 `task 1 mod +updatetime`
 or
 `task 1 mod +utime`

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ max_active_tasks=1
 erase_time_on_delete=false 
 # those are tags in taskwarrior.When you add one of them the time tracking will be deleted from timewarrior
 clear_time_tags=cleartime,ctime,deletetime,dtime
+update_time_tags=updatetime,utime,recalc
 create_time_when_add_task=false
 rate_per_hour=10
 rate_per_hour_decimals=2
@@ -106,4 +107,12 @@ or
 `task 1 mod +deletetime`
 or
 `task 1 mod +dtime`
+
+Update time tracking 
+
+`task 1 mod +updatetime`
+or
+`task 1 mod +utime`
+or
+`task 1 mod +recalc`
 

--- a/taskwarrior/hooks/library/Record.js
+++ b/taskwarrior/hooks/library/Record.js
@@ -15,13 +15,15 @@ class Record {
         this.data = data;
 
         if (this.data.tags) {
+            const clearTimeTags = config.getArray('clear_time_tags', settings.clearTimeTags);
+            const updateTimeTags = config.getArray('update_time_tags', settings.clearTimeTags);
             this.data.tags = this.data.tags.filter(tag => {
-                const clearTimeTags = config.getArray('clear_time_tags', settings.clearTimeTags);
                 const condition = !clearTimeTags.includes(tag);
                 if (!condition) {
                     this.cleartime = true;
                 }
-                return condition;
+
+                return condition && !updateTimeTags.includes(tag);
             });
         }
     }


### PR DESCRIPTION
Adds update tags to the filter in record. This allows to use `task 1 mod +update` to trigger a recalculation of the duration in taskwarrior.

It works similar to clear_time_tags, but it doesn't use a boolean to indicate that we are updating the time, as this is the default behaviour.