### PR TITLE
Add docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,34 @@
+name: Publish Docker image
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: hardliner66/trackwarrior
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM archlinux
+
+RUN pacman -Syu --needed --noconfirm base-devel expect
+RUN pacman -Syu --noconfirm git cmake man
+
+RUN git clone --recursive https://github.com/GothenburgBitFactory/taskshell.git && \
+    cd taskshell && cmake -DCMAKE_BUILD_TYPE=release . && make && make install
+
+RUN rm -rf taskshell
+
+RUN git clone https://github.com/gkssjovi/trackwarrior /trackwarrior
+COPY ./docker /trackwarrior-docker
+COPY ./docker/unbuffer /usr/bin/unbuffer
+
+RUN chmod +x /trackwarrior-docker/trackwarrior.sh
+RUN chmod +x /usr/bin/unbuffer
+
+RUN pacman -Syu --noconfirm task timew nodejs fish neovim taskwarrior-tui
+
+COPY ./docker/sysinit.vim /etc/xdg/nvim/sysinit.vim
+COPY ./docker/base.fish /etc/fish/conf.d/base.fish
+
+RUN ln -s /usr/bin/nvim /usr/bin/vi
+
+ENTRYPOINT [ "/trackwarrior-docker/trackwarrior.sh" ]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,28 @@
 This extension create a link between [taskwarrior](https://github.com/GothenburgBitFactory/taskwarrior) and  [timewarrior](https://github.com/GothenburgBitFactory/timewarrior) that allows you to keep track of time spend on tasks. 
 The time will be displayed in a new column in taskwarrior.
 
-## Installation
+## Docker
+
+```sh
+git clone https://github.com/gkssjovi/trackwarrior.git
+cd trackwarrior
+
+sudo ln -s "$PWD/trackwarrior-docker" /usr/local/bin/trackwarrior
+```
+
+### Use tasksh as main frontend
+```sh
+sudo rm /usr/local/bin/trackwarrior
+sudo ln -s "$PWD/trackwarrior-docker-tasksh" /usr/local/bin/trackwarrior
+```
+
+### Use taskwarrior-tui as main frontend
+```sh
+sudo rm /usr/local/bin/trackwarrior
+sudo ln -s "$PWD/trackwarrior-docker-tui" /usr/local/bin/trackwarrior
+```
+
+## Local Installation
 
 ```sh
 git clone https://github.com/gkssjovi/trackwarrior.git
@@ -54,7 +75,34 @@ To display the new column on the next report modify the `~/.taskrc` file
 report.next.labels=ID,St,Active,Age,Time,Rate,Total,...,Description,Urg
 report.next.columns=id,status.short,start.age,entry.age,trackwarrior,trackwarrior_rate,trackwarrior_total_amount,...,description,urgency
 ```
-## Examples
+
+## Usage
+If you installed the docker version, just run `trackwarrior` to open the configured fronted (default: fish shell).
+
+## Integrate with starship
+1) Locally install taskwarrior
+2) Install [starship](https://starship.rs/guide/#%F0%9F%9A%80-installation)
+3) Set the correct rights for your local taskwarrior to read the data from the container
+```sh
+# trackwarrior needs to be used at least once
+sudo chown "$(id -u):$(id -g)" ~/.trackwarrior-docker/.task/pending.data
+```
+
+4) Add the following to your starship.toml
+
+```toml
+[custom.current_task]
+command = """TASKRC=~/.trackwarrior-docker/.taskrc TASKDATA=~/.trackwarrior-docker/.task unbuffer task starship-project | head -5 | tail -1 | sed "s/No matches./[No active task]/" | xargs"""
+when = true
+shell = "bash"
+```
+
+## Usage Examples
+
+If you use a tasksh as a frontend, you can use the same commands as shown here,
+but without typing task in the beginning.
+
+If you use taskwarrior-tui as a frontend, check the [taskwarrior-tui documentation](https://kdheepak.com/taskwarrior-tui/) instead.
 
 ![Example](./assets/example.gif)
 

--- a/bin/local-trackwarrior-docker
+++ b/bin/local-trackwarrior-docker
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source_path="$(readlink -f "$(readlink "${BASH_SOURCE[0]}")")"
+source_dir="$(dirname "${source_path}")"
+
+docker build -t trackwarrior/trackwarrior:latest "$source_dir"
+
+"$source_dir"/trackwarror-docker "$@"

--- a/bin/trackwarrior-docker
+++ b/bin/trackwarrior-docker
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+docker run --rm \
+  -it \
+  -v "/etc/timezone:/etc/timezone:ro" \
+  -v "/etc/localtime:/etc/localtime:ro" \
+  -v "$HOME/.trackwarrior-docker:/root" \
+  trackwarrior/trackwarrior:latest "$@"

--- a/bin/trackwarrior-docker-tasksh
+++ b/bin/trackwarrior-docker-tasksh
@@ -5,5 +5,4 @@ set -euo pipefail
 source_path="$(readlink -f "$(readlink "${BASH_SOURCE[0]}")")"
 source_dir="$(dirname "${source_path}")"
 
-source_dir=$(dirname "$PRG")
 "$source_dir"/trackwarrior-docker tasksh

--- a/bin/trackwarrior-docker-tasksh
+++ b/bin/trackwarrior-docker-tasksh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source_path="$(readlink -f "$(readlink "${BASH_SOURCE[0]}")")"
+source_dir="$(dirname "${source_path}")"
+
+source_dir=$(dirname "$PRG")
+"$source_dir"/trackwarrior-docker tasksh

--- a/bin/trackwarrior-docker-tui
+++ b/bin/trackwarrior-docker-tui
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source_path="$(readlink -f "$(readlink "${BASH_SOURCE[0]}")")"
+source_dir="$(dirname "${source_path}")"
+
+"$source_dir"/trackwarrior-docker taskwarrior-tui

--- a/docker/base.fish
+++ b/docker/base.fish
@@ -1,0 +1,5 @@
+function fish_greeting
+end
+
+abbr ta 'task'
+abbr ti 'timew'

--- a/docker/sysinit.vim
+++ b/docker/sysinit.vim
@@ -1,0 +1,54 @@
+let mapleader = " "
+
+set tabstop=4
+set shiftwidth=4
+set noexpandtab
+set nobackup
+set nowritebackup
+set whichwrap+=<,>,h,l,[,]
+set incsearch
+set ignorecase
+set smartcase
+set smartindent
+set wildmenu
+set wildmode=full
+set foldmethod=indent
+set foldenable
+set foldlevelstart=10
+set foldnestmax=10
+set laststatus=2
+set splitright
+set splitbelow
+set backspace=indent,eol,start
+set nowrap
+set nohlsearch
+set timeoutlen=2000
+set mouse=
+set noswapfile
+set hidden
+
+" Better display for messages
+set cmdheight=2
+
+" You will have bad experience for diagnostic messages when it's default 4000.
+set updatetime=300
+
+" don't give |ins-completion-menu| messages.
+set shortmess+=c
+
+" always show signcolumns
+set signcolumn=yes
+
+set relativenumber
+set number
+
+nnoremap <silent><leader>k :bn<CR>
+nnoremap <silent><leader><leader>k :bn!<CR>
+nnoremap <silent><leader>j :bp<CR>
+nnoremap <silent><leader><leader>j :bp!<CR>
+nnoremap <silent><leader>d :bd<CR>
+nnoremap <silent><leader><leader>d :bd!<CR>
+nnoremap <silent><leader>w :w<CR>
+nnoremap <silent><leader>wq :wq<CR>
+nnoremap <silent><leader>q :q<CR>
+nnoremap <silent><leader>o gf<ESC>

--- a/docker/taskrc
+++ b/docker/taskrc
@@ -1,0 +1,73 @@
+# Taskwarrior program configuration file.
+# For more documentation, see http://taskwarrior.org or try 'man task', 'man task-color',
+# 'man task-sync' or 'man taskrc'
+
+# Here is an example of entries that use the default, override and blank values
+#   variable=foo   -- By specifying a value, this overrides the default
+#   variable=      -- By specifying no value, this means no default
+#   #variable=foo  -- By commenting out the line, or deleting it, this uses the default
+
+# Use the command 'task show' to see all defaults and overrides
+
+# Files
+data.location=~/.task
+
+# Color theme (uncomment one to use)
+#include /usr/share/taskwarrior/light-16.theme
+#include /usr/share/taskwarrior/light-256.theme
+#include /usr/share/taskwarrior/dark-16.theme
+#include /usr/share/taskwarrior/dark-256.theme
+#include /usr/share/taskwarrior/dark-red-256.theme
+#include /usr/share/taskwarrior/dark-green-256.theme
+#include /usr/share/taskwarrior/dark-blue-256.theme
+#include /usr/share/taskwarrior/dark-violets-256.theme
+#include /usr/share/taskwarrior/dark-yellow-green.theme
+#include /usr/share/taskwarrior/dark-gray-256.theme
+#include /usr/share/taskwarrior/dark-gray-blue-256.theme
+#include /usr/share/taskwarrior/solarized-dark-256.theme
+#include /usr/share/taskwarrior/solarized-light-256.theme
+#include /usr/share/taskwarrior/no-color.theme
+
+uda.trackwarrior.type=string
+uda.trackwarrior.label=Total active time
+uda.trackwarrior.values=
+
+uda.trackwarrior_rate.type=string
+uda.trackwarrior_rate.label=Rate
+uda.trackwarrior_rate.values=
+
+uda.trackwarrior_total_amount.type=string
+uda.trackwarrior_total_amount.label=Total amount
+uda.trackwarrior_total_amount.values=
+
+# this allow only one task to be active
+max_active_tasks=1 
+
+# when you delete the task, the time tracking will be also be deleted from timewarrior 
+erase_time_on_delete=false 
+
+# those are tags in taskwarrior.When you add one of them the time tracking will be deleted from timewarrior
+clear_time_tags=cleartime,ctime,deletetime,dtime
+rate_per_hour=10
+rate_per_hour_decimals=2
+rate_per_hour_project=Inbox:0,Other:10
+rate_format_with_spaces=10
+currency_format=de-DE,EUR
+
+report.next.labels=ID,St,Active,Age,Time,Description,Urg
+report.next.columns=id,status.short,start.age,entry.age,trackwarrior,description,urgency
+uda.reviewed.type=date
+uda.reviewed.label=Reviewed
+report._reviewed.description=Tasksh review report.  Adjust the filter to your needs.
+report._reviewed.columns=uuid
+report._reviewed.sort=reviewed+,modified+
+report._reviewed.filter=( reviewed.none: or reviewed.before:now-6days ) and ( +PENDING or +WAITING )
+urgency.user.tag.problem.coefficient=4.5
+urgency.user.tag.later.coefficient=-6.0
+
+create_time_when_add_task = true
+
+report.starship-project.description=Shows current task for use in starship
+report.starship-project.columns=id,project
+report.starship-project.filter=status:pending and +ACTIVE
+report.starship-project.sort=project+,start+

--- a/docker/trackwarrior.sh
+++ b/docker/trackwarrior.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+start_command=${1:-fish}
+
+yes | timew &> /dev/null
+yes | task &> /dev/null
+
+cp -n /root/.taskrc /trackwarrior-docker/old-taskrc
+
+mkdir -p /root/.config/fish/conf.d
+mkdir -p /root/.task/hooks
+mkdir -p /root/.timewarrior/extensions
+
+cmp --silent /trackwarrior-docker/old-taskrc /root/.taskrc && \
+  cp /trackwarrior-docker/taskrc /root/.taskrc
+cp -n /trackwarrior-docker/base.fish /root/.config/fish/conf.d/base.fish
+cp -n -r /trackwarrior/taskwarrior/hooks/* /root/.task/hooks/
+cp -n -r /trackwarrior/timewarrior/extensions/* /root/.timewarrior/extensions/
+
+cd /root/.task/hooks && chmod +x on-modify.trackwarrior on-add.trackwarrior
+cd /root/.timewarrior/extensions && chmod +x trackwarrior-duration.js trackwarrior-ids.js
+
+# change directory to home
+cd
+
+$start_command

--- a/docker/unbuffer
+++ b/docker/unbuffer
@@ -1,0 +1,31 @@
+#!/bin/sh
+# -*- tcl -*-
+# The next line is executed by /bin/sh, but not tcl \
+exec tclsh8.6 "$0" ${1+"$@"}
+
+package require Expect
+
+
+# -*- tcl -*-
+# Description: unbuffer stdout of a program
+# Author: Don Libes, NIST
+
+if {[string compare [lindex $argv 0] "-p"] == 0} {
+    # pipeline
+    set stty_init "-echo"
+    eval [list spawn -noecho] [lrange $argv 1 end]
+    close_on_eof -i $user_spawn_id 0
+    interact {
+	eof {
+	    # flush remaining output from child
+	    expect -timeout 1 -re .+
+	    return
+	}
+    }
+} else {
+    set stty_init "-opost"
+    set timeout -1
+    eval [list spawn -noecho] $argv
+    expect
+    exit [lindex [wait] 3]
+}


### PR DESCRIPTION
This adds a (slightly opinionated) docker container with trackwarrior already set up. It contains 3 helper scripts, which run the docker container with the correct options to properly and persistently track time with 3 different frontends: fish shell, tasksh and taskwarrior-ui.

The README has been updated to include information about the usage of the docker container.

I also added a github workflow to automatically push the container to dockerhub when a tag is created. But for that to work, you would need to create a docker account and set DOCKER_USERNAME and DOCKER_PASSWORD in the repository secrets.

I assumend the username will be trackwarrior and the repository will be trackwarrior as well, so the latest docker container would be: trackwarrior/trackwarrior:latest

If you want to publish the container under a different name, the name must be changed in all files.